### PR TITLE
Fix jhipster-framework.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <!-- The jhipster-framework version should be the same as the artifact version above -->
-        <jhipster-framework.version>3.10.0-SNAPSHOT</jhipster-framework.version>
+        <jhipster-framework.version>1.0.0-SNAPSHOT</jhipster-framework.version>
         <!-- The spring-boot version should be the same as the parent version above -->
         <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
 


### PR DESCRIPTION
Without this fix I'm getting error on running generated project (`jhipster-bom` and `generator-jhipster` main branch):
```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find tech.jhipster:jhipster-framework:3.10.0-SNAPSHOT.
```