### PR TITLE
Remove usage of Guava

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -48,7 +48,6 @@
         <cucumber-jvm.version>6.8.1</cucumber-jvm.version>
         <commons-io.version>2.8.0</commons-io.version>
         <de.flapdoodle.embed.mongo.version>2.2.0</de.flapdoodle.embed.mongo.version>
-        <guava.version>30.0-jre</guava.version>
         <hazelcast.version>4.0.3</hazelcast.version>
         <hazelcast-hibernate5.version>2.1.1</hazelcast-hibernate5.version>
         <!-- The hibernate version should match the one managed by
@@ -138,11 +137,6 @@
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-spring</artifactId>
                 <version>${cucumber-jvm.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.simple-spring-memcached</groupId>

--- a/jhipster-framework/src/test/java/tech/jhipster/config/JHipsterPropertiesTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/config/JHipsterPropertiesTest.java
@@ -23,11 +23,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Lists.newArrayList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class JHipsterPropertiesTest {
 
@@ -679,24 +682,17 @@ public class JHipsterPropertiesTest {
     public void testApiDocsProtocols() {
         JHipsterProperties.ApiDocs obj = properties.getApiDocs();
         String[] def = JHipsterDefaults.ApiDocs.protocols;
-        ArrayList<String> val;
-        if (def != null) {
-            val = newArrayList(def);
-            assertThat(obj.getProtocols()).containsExactlyElementsOf(newArrayList(val));
-        } else {
-            assertThat(obj.getProtocols()).isNull();
-            def = new String[1];
-            val = new ArrayList<>(1);
-        }
+        List<String> val = new ArrayList<>(Arrays.asList(def));
+        assertThat(obj.getProtocols()).containsExactlyElementsOf(val);
         val.add("1");
         obj.setProtocols(val.toArray(def));
-        assertThat(obj.getProtocols()).containsExactlyElementsOf(newArrayList(val));
+        assertThat(obj.getProtocols()).containsExactlyElementsOf(val);
     }
 
     @Test
     public void testApiDocsServers() {
         JHipsterProperties.ApiDocs obj = properties.getApiDocs();
-        assertThat(obj.getServers().length).isEqualTo(0);
+        assertThat(obj.getServers()).isEmpty();
         JHipsterProperties.ApiDocs.Server server = new JHipsterProperties.ApiDocs.Server();
         server.setUrl("url");
         server.setDescription("description");

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/BigDecimalFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/BigDecimalFilterTest.java
@@ -19,11 +19,11 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -149,13 +149,13 @@ public class BigDecimalFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -192,11 +192,11 @@ public class BigDecimalFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/BooleanFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/BooleanFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -112,13 +112,13 @@ public class BooleanFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         final BooleanFilter filter3 = new BooleanFilter();
         filter3.setEquals(value);
@@ -139,11 +139,11 @@ public class BooleanFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
     }
 

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/DoubleFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/DoubleFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -148,13 +148,13 @@ public class DoubleFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -191,11 +191,11 @@ public class DoubleFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/DurationFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/DurationFilterTest.java
@@ -19,11 +19,11 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -149,13 +149,13 @@ public class DurationFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -192,11 +192,11 @@ public class DurationFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/FilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/FilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -119,13 +119,13 @@ public class FilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         final Filter<Object> filter3 = new Filter<>();
         filter3.setEquals(value);
@@ -146,11 +146,11 @@ public class FilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         final Filter<Object> filter3 = new Filter<>();
         filter3.setEquals(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/FloatFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/FloatFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -148,13 +148,13 @@ public class FloatFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -191,11 +191,11 @@ public class FloatFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/InstantFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/InstantFilterTest.java
@@ -19,11 +19,11 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -149,13 +149,13 @@ public class InstantFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -192,11 +192,11 @@ public class InstantFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/IntegerFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/IntegerFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -148,13 +148,13 @@ public class IntegerFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -191,11 +191,11 @@ public class IntegerFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/LocalDateFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/LocalDateFilterTest.java
@@ -19,11 +19,11 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -149,13 +149,13 @@ public class LocalDateFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -192,11 +192,11 @@ public class LocalDateFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/LongFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/LongFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -148,13 +148,13 @@ public class LongFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -191,11 +191,11 @@ public class LongFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/RangeFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/RangeFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -148,13 +148,13 @@ public class RangeFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -191,11 +191,11 @@ public class RangeFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/ShortFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/ShortFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -148,13 +148,13 @@ public class ShortFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -191,11 +191,11 @@ public class ShortFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/StringFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/StringFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -132,13 +132,13 @@ public class StringFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setContains(value);
         assertThat(filter2).isNotEqualTo(filter);
@@ -167,11 +167,11 @@ public class StringFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setContains(value);
         filter2.setContains(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/UUIDFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/UUIDFilterTest.java
@@ -19,10 +19,10 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -115,13 +115,13 @@ public class UUIDFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         final UUIDFilter filter3 = new UUIDFilter();
         filter3.setEquals(value);
@@ -142,11 +142,11 @@ public class UUIDFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         final UUIDFilter filter3 = new UUIDFilter();
         filter3.setEquals(value);

--- a/jhipster-framework/src/test/java/tech/jhipster/service/filter/ZonedDateTimeFilterTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/filter/ZonedDateTimeFilterTest.java
@@ -19,11 +19,11 @@
 
 package tech.jhipster.service.filter;
 
-import com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -149,13 +149,13 @@ public class ZonedDateTimeFilterTest {
         assertThat(filter2).isNotEqualTo(filter);
         filter2.setSpecified(false);
         assertThat(filter).isEqualTo(filter2);
-        filter.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
-        filter.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
         assertThat(filter2).isNotEqualTo(filter);
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter).isEqualTo(filter2);
         filter.setGreaterThan(value);
         assertThat(filter).isNotEqualTo(filter2);
@@ -192,11 +192,11 @@ public class ZonedDateTimeFilterTest {
         filter.setSpecified(false);
         filter2.setSpecified(false);
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setIn(Lists.newArrayList(value, value));
-        filter2.setIn(Lists.newArrayList(value, value));
+        filter.setIn(Arrays.asList(value, value));
+        filter2.setIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
-        filter.setNotIn(Lists.newArrayList(value, value));
-        filter2.setNotIn(Lists.newArrayList(value, value));
+        filter.setNotIn(Arrays.asList(value, value));
+        filter2.setNotIn(Arrays.asList(value, value));
         assertThat(filter.hashCode()).isEqualTo(filter2.hashCode());
         filter.setGreaterThan(value);
         filter2.setGreaterThan(value);


### PR DESCRIPTION
- dependency management is defined, but never used
- unit tests were using it, but without explicitly declaring the dependency