### PR TITLE
Remove explicit redeclaration of hibernate.version

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -51,9 +51,6 @@
         <guava.version>30.0-jre</guava.version>
         <hazelcast.version>4.0.3</hazelcast.version>
         <hazelcast-hibernate5.version>2.1.1</hazelcast-hibernate5.version>
-        <!-- The hibernate version should match the one managed by
-        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
-        <hibernate.version>5.4.22.Final</hibernate.version>
         <infinispan.version>10.1.8.Final</infinispan.version>
         <infinispan-spring-boot-starter-embedded.version>2.2.4.Final</infinispan-spring-boot-starter-embedded.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>


### PR DESCRIPTION
It's already inherited from spring-boot-dependencies
Removing it reduce maintenance effort for us