### PR TITLE
add jhipster.api-docs.management-include-pattern property

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterDefaults.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterDefaults.java
@@ -163,6 +163,7 @@ public interface JHipsterDefaults {
         String license = null;
         String licenseUrl = null;
         String defaultIncludePattern = "/api/.*";
+        String managementIncludePattern = "/management/.*";
         String host = null;
         String[] protocols = {};
         boolean useDefaultResponseMessages = true;

--- a/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterProperties.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterProperties.java
@@ -867,6 +867,8 @@ public class JHipsterProperties {
 
         private String defaultIncludePattern = JHipsterDefaults.ApiDocs.defaultIncludePattern;
 
+        private String managementIncludePattern = JHipsterDefaults.ApiDocs.managementIncludePattern;
+
         private String host = JHipsterDefaults.ApiDocs.host;
 
         private String[] protocols = JHipsterDefaults.ApiDocs.protocols;
@@ -953,6 +955,14 @@ public class JHipsterProperties {
 
         public void setDefaultIncludePattern(String defaultIncludePattern) {
             this.defaultIncludePattern = defaultIncludePattern;
+        }
+
+        public String getManagementIncludePattern() {
+            return managementIncludePattern;
+        }
+
+        public void setManagementIncludePattern(String managementIncludePattern) {
+            this.managementIncludePattern = managementIncludePattern;
         }
 
         public String getHost() {

--- a/jhipster-framework/src/main/java/tech/jhipster/config/apidoc/SpringfoxAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/apidoc/SpringfoxAutoConfiguration.java
@@ -135,16 +135,13 @@ public class SpringfoxAutoConfiguration {
      * Springfox configuration for the management endpoints (actuator) OpenAPI docs.
      *
      * @param appName               the application name
-     * @param managementContextPath the path to access management endpoints
      * @return the Springfox configuration
      */
     @Bean
     @ConditionalOnClass(name = "org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties")
-    @ConditionalOnProperty("management.endpoints.web.base-path")
     @ConditionalOnExpression("'${management.endpoints.web.base-path}'.length() > 0")
     @ConditionalOnMissingBean(name = "openAPISpringfoxManagementDocket")
-    public Docket openAPISpringfoxManagementDocket(@Value("${spring.application.name:application}") String appName,
-                                                   @Value("${management.endpoints.web.base-path}") String managementContextPath) {
+    public Docket openAPISpringfoxManagementDocket(@Value("${spring.application.name:application}") String appName) {
 
         ApiInfo apiInfo = new ApiInfo(
             StringUtils.capitalize(appName) + " " + MANAGEMENT_TITLE_SUFFIX,
@@ -175,7 +172,7 @@ public class SpringfoxAutoConfiguration {
             .genericModelSubstitutes(ResponseEntity.class)
             .ignoredParameterTypes(Pageable.class)
             .select()
-            .paths(regex(managementContextPath + ".*"))
+            .paths(regex(properties.getManagementIncludePattern()))
             .build();
     }
 

--- a/jhipster-framework/src/main/java/tech/jhipster/config/apidoc/SpringfoxAutoConfiguration.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/apidoc/SpringfoxAutoConfiguration.java
@@ -139,7 +139,6 @@ public class SpringfoxAutoConfiguration {
      */
     @Bean
     @ConditionalOnClass(name = "org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties")
-    @ConditionalOnExpression("'${management.endpoints.web.base-path}'.length() > 0")
     @ConditionalOnMissingBean(name = "openAPISpringfoxManagementDocket")
     public Docket openAPISpringfoxManagementDocket(@Value("${spring.application.name:application}") String appName) {
 

--- a/jhipster-framework/src/test/java/tech/jhipster/config/JHipsterPropertiesTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/config/JHipsterPropertiesTest.java
@@ -633,6 +633,16 @@ public class JHipsterPropertiesTest {
     }
 
     @Test
+    public void testApiDocsManagementIncludePattern() {
+        JHipsterProperties.ApiDocs obj = properties.getApiDocs();
+        String val = JHipsterDefaults.ApiDocs.managementIncludePattern;
+        assertThat(obj.getManagementIncludePattern()).isEqualTo(val);
+        val = "1" + val;
+        obj.setManagementIncludePattern(val);
+        assertThat(obj.getManagementIncludePattern()).isEqualTo(val);
+    }
+
+    @Test
     public void testApiDocsHost() {
         JHipsterProperties.ApiDocs obj = properties.getApiDocs();
         String val = JHipsterDefaults.ApiDocs.host;


### PR DESCRIPTION
this property allows custom setting of the management include pattern to support advanced use cases such as using a custom server path.