### PR TITLE
Make spring-boot-starter-web optional

### DIFF
--- a/jhipster-framework/pom.xml
+++ b/jhipster-framework/pom.xml
@@ -193,6 +193,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
It should be defined at the project level, and also it shouldn't be set for projects using webflux