### PR TITLE
Downgrade neo4j-migrations to 0.0.13 because 0.1.1 requires spring boot 2.4

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -59,7 +59,7 @@
         <mapstruct.version>1.4.1.Final</mapstruct.version>
         <mongock.version>4.1.19</mongock.version>
         <mssql-jdbc.version>8.4.1.jre8</mssql-jdbc.version>
-        <neo4j-migrations.version>0.1.1</neo4j-migrations.version>
+        <neo4j-migrations.version>0.0.13</neo4j-migrations.version>
         <mysql-jdbc.version>8.0.22</mysql-jdbc.version>
         <oracle-jdbc.version>19.8.0.0</oracle-jdbc.version>
         <problem-spring.version>0.26.2</problem-spring.version>


### PR DESCRIPTION
Causes tests to fail