### PR TITLE
Spring Cloud Config upgrade handed by spring-cloud-dependencies:2020.0.1

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -71,9 +71,6 @@
         <redisson.version>3.15.0</redisson.version>
         <reflections.version>0.9.11</reflections.version>
         <spring-cloud.version>2020.0.1</spring-cloud.version>
-        <!-- Upgrade Spring Cloud Config 3.0.1 to fix issues in 2020.0 (Spring Boot 2.4.2) -->
-        <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2020.0-Release-Notes -->
-        <spring-cloud-config-dependencies.version>3.0.2</spring-cloud-config-dependencies.version>
         <spring-cloud-netflix.version>2.2.6.RELEASE</spring-cloud-netflix.version>
         <!-- Spring Cloud Netflix pulls in an old version of Guava -->
         <guava.version>30.0-jre</guava.version>
@@ -709,15 +706,6 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>${aws-java-sdk-bom.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <!-- Upgrade to Spring Cloud Config 3.0.1 to support retry with spring.config.import -->
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-config-dependencies</artifactId>
-                <version>${spring-cloud-config-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Spring Cloud Config 3.0.2 is included in this update.

https://search.maven.org/artifact/org.springframework.cloud/spring-cloud-dependencies/2020.0.1/pom