### PR TITLE
add method to start h2 webserver console inside reactive environment

### DIFF
--- a/jhipster-framework/src/test/java/tech/jhipster/config/h2/H2ConfigurationHelperTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/config/h2/H2ConfigurationHelperTest.java
@@ -1,0 +1,20 @@
+package tech.jhipster.config.h2;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class H2ConfigurationHelperTest {
+
+    @Test
+    void initH2Console() {
+
+        assertThatCode(() -> {
+            H2ConfigurationHelper.initH2Console("src/test/resources");
+            new URL("http://localhost:8092").openConnection().connect();
+        })
+            .doesNotThrowAnyException();
+    }
+}

--- a/jhipster-framework/src/test/resources/.h2.server.properties
+++ b/jhipster-framework/src/test/resources/.h2.server.properties
@@ -1,0 +1,5 @@
+#H2 Server Properties
+0=JHipster H2 (Memory)|org.h2.Driver|jdbc\:h2\:mem\:jhbomtest|jhbomtest
+webAllowOthers=true
+webPort=8092
+webSSL=false


### PR DESCRIPTION
This is a preparation for https://github.com/jhipster/generator-jhipster/issues/13699 to start the h2 console without/outside a servlet context so we can have it when using reactive. Micronaut blueprint is doing the same as it runs on netty by default and no servlet context is available.
 
PR in the main generator will follow.