### PR TITLE
Add back com.google.guava dependencies

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -72,7 +72,6 @@
         <reflections.version>0.9.11</reflections.version>
         <spring-cloud.version>2020.0.1</spring-cloud.version>
         <spring-cloud-netflix.version>2.2.7.RELEASE</spring-cloud-netflix.version>
-        <!-- Spring Cloud Netflix pulls in an old version of Guava -->
         <guava.version>30.1-jre</guava.version>
         <spring-cloud-security.version>2.2.4.RELEASE</spring-cloud-security.version>
         <spring-data-neo4j-rx.version>1.1.1</spring-data-neo4j-rx.version>
@@ -623,6 +622,11 @@
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
                 <version>${spring-cloud-netflix.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.security</groupId>


### PR DESCRIPTION
Needed by webflux-gateway-jwt with MongoDB