### PR TITLE
update spring-data:neo4j to 6.0.6

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -74,6 +74,7 @@
         <guava.version>30.1-jre</guava.version>
         <spring-cloud-security.version>2.2.4.RELEASE</spring-cloud-security.version>
         <spring-data-neo4j-rx.version>1.1.1</spring-data-neo4j-rx.version>
+        <spring-data-neo4j.version>6.0.6</spring-data-neo4j.version>
         <spring-security-jwt.version>1.1.1.RELEASE</spring-security-jwt.version>
         <spring-security-oauth.version>2.5.0.RELEASE</spring-security-oauth.version>
         <springfox.version>3.0.0</springfox.version>
@@ -651,6 +652,11 @@
                 <groupId>eu.michael-simons.neo4j</groupId>
                 <artifactId>neo4j-migrations-spring-boot-starter</artifactId>
                 <version>${neo4j-migrations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-neo4j</artifactId>
+                <version>${spring-data-neo4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.springfox</groupId>


### PR DESCRIPTION
This PR updates `org.springframework.data:spring-data-neo4j` to latest `6.0.6` which removes a [blocking call in the reactive template](https://github.com/spring-projects/spring-data-neo4j/issues/2169). 

This closes https://github.com/jhipster/generator-jhipster/issues/14196