### PR TITLE
Downgrade prometheus simple client version to 0.9.0

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -66,7 +66,7 @@
         <problem-spring.version>0.26.2</problem-spring.version>
         <problem-spring-web.version>${problem-spring.version}</problem-spring-web.version>
         <problem-spring-webflux.version>${problem-spring.version}</problem-spring-webflux.version>
-        <prometheus-simpleclient.version>0.10.0</prometheus-simpleclient.version>
+        <prometheus-simpleclient.version>0.9.0</prometheus-simpleclient.version>
         <redisson.version>3.15.3</redisson.version>
         <reflections.version>0.9.11</reflections.version>
         <spring-cloud.version>2020.0.2</spring-cloud.version>


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/14620

Related with:
- https://github.com/micrometer-metrics/micrometer/issues/2555
- https://github.com/prometheus/client_java/releases/tag/parent-0.10.0