### PR TITLE
Fix git properties no longer being interpolated in application.yaml files

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterConfiguration.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterConfiguration.java
@@ -1,10 +1,17 @@
 package tech.jhipster.config;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.annotation.PropertySources;
 
 /**
  * Configure the usage of JHipsterProperties.
  */
 @EnableConfigurationProperties(JHipsterProperties.class)
+// Load some properties into the environment from files to make them available for interpolation in application.yaml.
+@PropertySources({
+    @PropertySource(value = "classpath:git.properties", ignoreResourceNotFound = true),
+    @PropertySource(value = "classpath:META-INF/build-info.properties", ignoreResourceNotFound = true)
+})
 public class JHipsterConfiguration {
 }

--- a/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterProperties.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/JHipsterProperties.java
@@ -38,10 +38,6 @@ import java.util.Map;
  * files if they are found in the classpath.</p>
  */
 @ConfigurationProperties(prefix = "jhipster", ignoreUnknownFields = false)
-@PropertySources({
-    @PropertySource(value = "classpath:git.properties", ignoreResourceNotFound = true),
-    @PropertySource(value = "classpath:META-INF/build-info.properties", ignoreResourceNotFound = true)
-})
 public class JHipsterProperties {
 
     private final Async async = new Async();


### PR DESCRIPTION
Following recent changes in Spring Boot, those properties were no longer available for interpolation in `application.yaml` files during boot. 