### PR TITLE
Fix local jhipster version script

### DIFF
--- a/test-integration/scripts/10-replace-version-jhipster.sh
+++ b/test-integration/scripts/10-replace-version-jhipster.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 set -e
-source "$JHI_SCRIPTS/00-init-env.sh"
+if [[ $JHI_SCRIPTS != '' ]]; then
+    source "$JHI_SCRIPTS/00-init-env.sh"
+fi
 
 if [[ $JHI_VERSION == '' ]]; then
     JHI_VERSION=0.0.0-CICD


### PR DESCRIPTION
With the recent changes, I couldn't launch the script any more. It's for fixing this issue:

```
➜ ./jhipster-version.sh 7.1.0         
test-integration/scripts/10-replace-version-jhipster.sh: ligne 4: /00-init-env.sh: Aucun fichier ou dossier de ce type
```
