### PR TITLE
Improvements to workflows.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -33,7 +33,7 @@ on:
       - '*'
 jobs:
   applications:
-    name: ${{ matrix.app-type }}
+    name: ${{ matrix.app-sample }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        app-type:
+        app-sample:
           - ngx-default
           - ngx-mysql-es-noi18n-mapsid
           - ngx-mariadb-oauth2-infinispan
@@ -61,61 +61,61 @@ jobs:
           - ngx-gradle-mongodb-kafka-cucumber
           - ngx-gradle-h2disk-ws-nocache
         include:
-          - app-type: ngx-default
+          - app-sample: ngx-default
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: ngx-mysql-es-noi18n-mapsid
+          - app-sample: ngx-mysql-es-noi18n-mapsid
             entity: sql
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: ngx-mariadb-oauth2-infinispan
+          - app-sample: ngx-mariadb-oauth2-infinispan
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: ngx-mongodb-kafka-cucumber
+          - app-sample: ngx-mongodb-kafka-cucumber
             entity: mongodb
             environment: dev
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: ngx-h2mem-ws-nol2
+          - app-sample: ngx-h2mem-ws-nol2
             entity: sql
             environment: dev
-            war: 0 # TODO: need change to 1, when maven+war is fixed
+            war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: ngx-gradle-fr
+          - app-sample: ngx-gradle-fr
             entity: sql
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: ngx-gradle-mysql-es-noi18n-mapsid
+          - app-sample: ngx-gradle-mysql-es-noi18n-mapsid
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: ngx-gradle-mariadb-oauth2-infinispan
+          - app-sample: ngx-gradle-mariadb-oauth2-infinispan
             entity: sql
             environment: dev
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: ngx-gradle-mongodb-kafka-cucumber
+          - app-sample: ngx-gradle-mongodb-kafka-cucumber
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: ngx-gradle-h2disk-ws-nocache
+          - app-sample: ngx-gradle-h2disk-ws-nocache
             entity: sql
             environment: dev
             war: 1
@@ -125,6 +125,10 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
+      - name: 'SETUP: Checkout jhipster-bom'
+        uses: actions/checkout@v2.3.4
+        with:
+          path: jhipster-bom
       - name: 'SETUP: Checkout generator-jhipster'
         uses: actions/checkout@v2.3.4
         with:
@@ -133,20 +137,17 @@ jobs:
           # shows 5 commits at log
           fetch-depth: 5
           ref: main
-      - name: 'SETUP: Checkout jhipster'
-        uses: actions/checkout@v2.3.4
-        with:
-          path: jhipster-bom
       - name: 'SETUP: environment'
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
           entities-sample: ${{ matrix.entity }}
-          application-sample: ${{ matrix.app-type }}
+          application-sample: ${{ matrix.app-sample }}
           application-environment: ${{ matrix.environment }}
           application-packaging: ${{ (matrix.war == 1 && 'war') || 'jar' }}
           enable-testcontainers: ${{ matrix.testcontainers == 1 }}
           generator-jhipster-branch: local
+          jhipster-bom-branch: auto
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
@@ -187,25 +188,27 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers'
-        run: npm run ci:e2e:prepare
+      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+        run: $JHI_SCRIPTS/20-docker-compose-npm.sh
       - name: 'TESTS: backend'
-        run: npm run ci:backend:test
+        id: backend
+        run: $JHI_SCRIPTS/21-tests-backend-npm.sh
       - name: 'TESTS: frontend'
-        run: npm run ci:frontend:test
+        run: $JHI_SCRIPTS/22-tests-frontend-npm.sh
       - name: 'TESTS: packaging'
-        run: npm run ci:e2e:package
-      - name: 'E2E: Run'
+        run: $JHI_SCRIPTS/23-package-npm.sh
+      - name: 'TESTS: End-to-End'
         id: e2e
-        run: npm run ci:e2e:run --if-present
+        run: $JHI_SCRIPTS/24-tests-e2e-npm.sh
+      - name: 'BACKEND: Store failure logs'
+        uses: actions/upload-artifact@v2
+        if: always() && steps.backend.outcome == 'failure'
+        with:
+          name: log-${{ matrix.app-sample }}
+          path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
       - name: 'E2E: Store failure screenshots'
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.app-type }}
+          name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
-        run: $JHI_SCRIPTS/25-sonar-analyze.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -33,7 +33,7 @@ on:
       - '*'
 jobs:
   applications:
-    name: ${{ matrix.app-type }}
+    name: ${{ matrix.app-sample }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -49,75 +49,65 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        app-type:
+        app-sample:
           - react-default
           - react-maven-mysql-es-noi18n-mapsid
           - react-maven-h2mem-memcached
           - react-maven-cassandra-session-redis
-          #                    - react-maven-couchbase-caffeine
           - react-gradle-mysql-es-noi18n-mapsid
           - react-gradle-h2mem-memcached
           - react-gradle-cassandra-session-redis
-        #                    - react-gradle-couchbase-caffeine
         include:
-          - app-type: react-default
+          - app-sample: react-default
             entity: sql
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: react-maven-mysql-es-noi18n-mapsid
+          - app-sample: react-maven-mysql-es-noi18n-mapsid
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: react-maven-h2mem-memcached
+          - app-sample: react-maven-h2mem-memcached
             entity: sql
             environment: prod
-            war: 0 # TODO: need change to 1, when maven+war is fixed
+            war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: react-maven-cassandra-session-redis
+          - app-sample: react-maven-cassandra-session-redis
             entity: cassandra
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          #                    - app-type: react-maven-couchbase-caffeine
-          #                      entity: couchbase
-          #                      environment: prod
-          #                      war: 0
-          #                      e2e: 0
-          #                      testcontainers: 0
-          - app-type: react-gradle-mysql-es-noi18n-mapsid
+          - app-sample: react-gradle-mysql-es-noi18n-mapsid
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: react-gradle-h2mem-memcached
+          - app-sample: react-gradle-h2mem-memcached
             entity: sql
             environment: prod
             war: 1
             e2e: 1
             testcontainers: 0
-          - app-type: react-gradle-cassandra-session-redis
+          - app-sample: react-gradle-cassandra-session-redis
             entity: cassandra
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-    #                    - app-type: react-gradle-couchbase-caffeine
-    #                      entity: couchbase
-    #                      environment: prod
-    #                      war: 0
-    #                      e2e: 1
-    #                      testcontainers: 0
     steps:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
+      - name: 'SETUP: Checkout jhipster-bom'
+        uses: actions/checkout@v2.3.4
+        with:
+          path: jhipster-bom
       - name: 'SETUP: Checkout generator-jhipster'
         uses: actions/checkout@v2.3.4
         with:
@@ -126,20 +116,17 @@ jobs:
           # shows 5 commits at log
           fetch-depth: 5
           ref: main
-      - name: 'SETUP: Checkout jhipster'
-        uses: actions/checkout@v2.3.4
-        with:
-          path: jhipster-bom
       - name: 'SETUP: environment'
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
           entities-sample: ${{ matrix.entity }}
-          application-sample: ${{ matrix.app-type }}
+          application-sample: ${{ matrix.app-sample }}
           application-environment: ${{ matrix.environment }}
           application-packaging: ${{ (matrix.war == 1 && 'war') || 'jar' }}
           enable-testcontainers: ${{ matrix.testcontainers == 1 }}
           generator-jhipster-branch: local
+          jhipster-bom-branch: auto
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
@@ -180,25 +167,27 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers'
-        run: npm run ci:e2e:prepare
+      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+        run: $JHI_SCRIPTS/20-docker-compose-npm.sh
       - name: 'TESTS: backend'
-        run: npm run ci:backend:test
+        id: backend
+        run: $JHI_SCRIPTS/21-tests-backend-npm.sh
       - name: 'TESTS: frontend'
-        run: npm run ci:frontend:test
+        run: $JHI_SCRIPTS/22-tests-frontend-npm.sh
       - name: 'TESTS: packaging'
-        run: npm run ci:e2e:package
-      - name: 'E2E: Run'
+        run: $JHI_SCRIPTS/23-package-npm.sh
+      - name: 'TESTS: End-to-End'
         id: e2e
-        run: npm run ci:e2e:run --if-present
+        run: $JHI_SCRIPTS/24-tests-e2e-npm.sh
+      - name: 'BACKEND: Store failure logs'
+        uses: actions/upload-artifact@v2
+        if: always() && steps.backend.outcome == 'failure'
+        with:
+          name: log-${{ matrix.app-sample }}
+          path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
       - name: 'E2E: Store failure screenshots'
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.app-type }}
+          name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
-        run: $JHI_SCRIPTS/25-sonar-analyze.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -33,7 +33,7 @@ on:
       - '*'
 jobs:
   applications:
-    name: ${{ matrix.app-type }}
+    name: ${{ matrix.app-sample }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        app-type:
+        app-sample:
           - vue-default
           - vue-noi18n
           - vue-fulli18n-es
@@ -57,67 +57,52 @@ jobs:
           - vue-gradle-session
           - vue-ws-theme
           - vue-oauth2
-          #                    - vue-couchbase
           - vue-mongodb-kafka-cucumber
           - vue-session-cassandra-fr
         include:
-          - app-type: vue-default
+          - app-sample: vue-default
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-noi18n
+          - app-sample: vue-noi18n
             entity: sqlfull
             environment: prod
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-fulli18n-es
+          - app-sample: vue-fulli18n-es
             entity: sql
             environment: prod
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-gateway
+          - app-sample: vue-gateway
             entity: sql
-            environment: dev,webapp
+            environment: dev
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-gradle-session
+          - app-sample: vue-gradle-session
             entity: sql
-            environment: dev,webapp
+            environment: dev
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-ws-theme
+          - app-sample: vue-ws-theme
             entity: sql
-            environment: dev,webapp
+            environment: dev
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-oauth2
+          - app-sample: vue-oauth2
             entity: sql
             environment: prod
             war: 0
             e2e: 1
-            testcontainers: 0
-          #                    - app-type: vue-couchbase
-          #                      entity: couchbase
-          #                      environment: dev,webapp
-          #                      war: 0
-          #                      e2e: 1
-          #                      testcontainers: 0
-          - app-type: vue-mongodb-kafka-cucumber
+          - app-sample: vue-mongodb-kafka-cucumber
             entity: mongodb
-            environment: dev,webapp
+            environment: dev
             war: 0
             e2e: 1
-            testcontainers: 0
-          - app-type: vue-session-cassandra-fr
+          - app-sample: vue-session-cassandra-fr
             entity: cassandra
-            environment: dev,webapp
+            environment: dev
             war: 0
             e2e: 1
             testcontainers: 1
@@ -125,6 +110,10 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
+      - name: 'SETUP: Checkout jhipster-bom'
+        uses: actions/checkout@v2.3.4
+        with:
+          path: jhipster-bom
       - name: 'SETUP: Checkout generator-jhipster'
         uses: actions/checkout@v2.3.4
         with:
@@ -133,20 +122,17 @@ jobs:
           # shows 5 commits at log
           fetch-depth: 5
           ref: main
-      - name: 'SETUP: Checkout jhipster'
-        uses: actions/checkout@v2.3.4
-        with:
-          path: jhipster-bom
       - name: 'SETUP: environment'
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
           entities-sample: ${{ matrix.entity }}
-          application-sample: ${{ matrix.app-type }}
+          application-sample: ${{ matrix.app-sample }}
           application-environment: ${{ matrix.environment }}
           application-packaging: ${{ (matrix.war == 1 && 'war') || 'jar' }}
           enable-testcontainers: ${{ matrix.testcontainers == 1 }}
           generator-jhipster-branch: local
+          jhipster-bom-branch: auto
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
@@ -154,7 +140,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: 'SETUP: load cache'
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -187,25 +173,27 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers'
-        run: npm run ci:e2e:prepare
+      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+        run: $JHI_SCRIPTS/20-docker-compose-npm.sh
       - name: 'TESTS: backend'
-        run: npm run ci:backend:test
+        id: backend
+        run: $JHI_SCRIPTS/21-tests-backend-npm.sh
       - name: 'TESTS: frontend'
-        run: npm run ci:frontend:test
+        run: $JHI_SCRIPTS/22-tests-frontend-npm.sh
       - name: 'TESTS: packaging'
-        run: npm run ci:e2e:package
-      - name: 'E2E: Run'
+        run: $JHI_SCRIPTS/23-package-npm.sh
+      - name: 'TESTS: End-to-End'
         id: e2e
-        run: npm run ci:e2e:run --if-present
+        run: $JHI_SCRIPTS/24-tests-e2e-npm.sh
+      - name: 'BACKEND: Store failure logs'
+        uses: actions/upload-artifact@v2
+        if: always() && steps.backend.outcome == 'failure'
+        with:
+          name: log-${{ matrix.app-sample }}
+          path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
       - name: 'E2E: Store failure screenshots'
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.app-type }}
+          name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
-        run: $JHI_SCRIPTS/25-sonar-analyze.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -33,7 +33,7 @@ on:
       - '*'
 jobs:
   applications:
-    name: ${{ matrix.app-type }}
+    name: ${{ matrix.app-sample }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -49,73 +49,52 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        app-type:
+        app-sample:
           - webflux-mongodb
           - webflux-mongodb-es-session
           - webflux-mongodb-oauth2
           - webflux-gateway-jwt
           - webflux-gateway-oauth2
-          #                    - webflux-couchbase
-          #                    - webflux-couchbase-es-oauth2
           - webflux-psql
-          #                    - webflux-mysql
           - webflux-mariadb-gradle
         include:
-          - app-type: webflux-mongodb
+          - app-sample: webflux-mongodb
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: webflux-mongodb-es-session
+          - app-sample: webflux-mongodb-es-session
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: webflux-mongodb-oauth2
+          - app-sample: webflux-mongodb-oauth2
             entity: mongodb
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          - app-type: webflux-gateway-jwt
+          - app-sample: webflux-gateway-jwt
             entity: none
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          - app-type: webflux-gateway-oauth2
+          - app-sample: webflux-gateway-oauth2
             entity: none
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 1
-          #                    - app-type: webflux-couchbase
-          #                      entity: couchbase
-          #                      environment: prod
-          #                      war: 0
-          #                      e2e: 1
-          #                      testcontainers: 0
-          #                    - app-type: webflux-couchbase-es-oauth2
-          #                      entity: couchbase
-          #                      environment: prod
-          #                      war: 0
-          #                      e2e: 1
-          #                      testcontainers: 0
-          - app-type: webflux-psql
+          - app-sample: webflux-psql
             entity: sql
             environment: prod
             war: 0
             e2e: 1
             testcontainers: 0
-          #                    - app-type: webflux-mysql
-          #                      entity: sqllight
-          #                      environment: prod
-          #                      war: 0
-          #                      e2e: 1
-          #                      testcontainers: 1
-          - app-type: webflux-mariadb-gradle
+          - app-sample: webflux-mariadb-gradle
             entity: sqllight
             environment: prod
             war: 0
@@ -125,6 +104,10 @@ jobs:
       #----------------------------------------------------------------------
       # Install all tools and check configuration
       #----------------------------------------------------------------------
+      - name: 'SETUP: Checkout jhipster-bom'
+        uses: actions/checkout@v2.3.4
+        with:
+          path: jhipster-bom
       - name: 'SETUP: Checkout generator-jhipster'
         uses: actions/checkout@v2.3.4
         with:
@@ -133,20 +116,17 @@ jobs:
           # shows 5 commits at log
           fetch-depth: 5
           ref: main
-      - name: 'SETUP: Checkout jhipster'
-        uses: actions/checkout@v2.3.4
-        with:
-          path: jhipster-bom
       - name: 'SETUP: environment'
         id: setup
         uses: ./generator-jhipster/.github/actions/setup
         with:
           entities-sample: ${{ matrix.entity }}
-          application-sample: ${{ matrix.app-type }}
+          application-sample: ${{ matrix.app-sample }}
           application-environment: ${{ matrix.environment }}
           application-packaging: ${{ (matrix.war == 1 && 'war') || 'jar' }}
           enable-testcontainers: ${{ matrix.testcontainers == 1 }}
           generator-jhipster-branch: local
+          jhipster-bom-branch: auto
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ steps.setup.outputs.node-version }}
@@ -154,7 +134,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: ${{ steps.setup.outputs.java-version }}
-      - name: 'SETUP: load npm cache'
+      - name: 'SETUP: load cache'
         uses: actions/cache@v2.1.6
         with:
           path: |
@@ -187,25 +167,27 @@ jobs:
       #----------------------------------------------------------------------
       # Launch tests
       #----------------------------------------------------------------------
-      - name: 'TESTS: Start docker-compose containers'
-        run: npm run ci:e2e:prepare
+      - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+        run: $JHI_SCRIPTS/20-docker-compose-npm.sh
       - name: 'TESTS: backend'
-        run: npm run ci:backend:test
+        id: backend
+        run: $JHI_SCRIPTS/21-tests-backend-npm.sh
       - name: 'TESTS: frontend'
-        run: npm run ci:frontend:test
+        run: $JHI_SCRIPTS/22-tests-frontend-npm.sh
       - name: 'TESTS: packaging'
-        run: npm run ci:e2e:package
-      - name: 'E2E: Run'
+        run: $JHI_SCRIPTS/23-package-npm.sh
+      - name: 'TESTS: End-to-End'
         id: e2e
-        run: npm run ci:e2e:run --if-present
+        run: $JHI_SCRIPTS/24-tests-e2e-npm.sh
+      - name: 'BACKEND: Store failure logs'
+        uses: actions/upload-artifact@v2
+        if: always() && steps.backend.outcome == 'failure'
+        with:
+          name: log-${{ matrix.app-sample }}
+          path: ${{ steps.setup.outputs.application-path }}/*/test-results/**/*.xml
       - name: 'E2E: Store failure screenshots'
         uses: actions/upload-artifact@v2
         if: always() && steps.e2e.outcome == 'failure'
         with:
-          name: screenshots-${{ matrix.app-type }}
+          name: screenshots-${{ matrix.app-sample }}
           path: ${{ steps.setup.outputs.application-path }}/*/cypress/screenshots
-      - name: 'ANALYSIS: Sonar analysis'
-        run: $JHI_SCRIPTS/25-sonar-analyze.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/test-integration/scripts/10-replace-version-jhipster.sh
+++ b/test-integration/scripts/10-replace-version-jhipster.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 set -e
-if [[ $JHI_SCRIPTS != '' ]]; then
-    source "$JHI_SCRIPTS/00-init-env.sh"
-fi
 
 if [[ $JHI_VERSION == '' ]]; then
     JHI_VERSION=0.0.0-CICD


### PR DESCRIPTION
- Rename `app-type` to `app-sample`.
- Set jhipster-bom-branch to `auto`, so changing the default value at the composite action won't break builds.
- Switch from npm run * to bash scripts.
- Store backend logs.
- Remove sonar step.
- Don't import 00-init-env.sh at 10-replace-version-jhipster.sh