### PR TITLE
Add distinct specification to QueryService

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/service/QueryService.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/service/QueryService.java
@@ -527,4 +527,17 @@ public abstract class QueryService<ENTITY> {
         return "%" + txt.toUpperCase() + '%';
     }
 
+    /**
+     * <p>distinct.</p>
+     *
+     * @param distinct a boolean.
+     * @return a {@link org.springframework.data.jpa.domain.Specification} object.
+     */
+    protected Specification<ENTITY> distinct(boolean distinct) {
+        return (root, query, cb) -> {
+            query.distinct(distinct);
+            return null;
+        };
+    }
+
 }


### PR DESCRIPTION
This would allow to use the distinct method in the generated EntityQueryService.

So this

```java
Specification<ENTITY> specification = Specification.where(null);
```

would result in this

```java
Specification<ENTITY> specification = Specification.where(distinct(false));
```

So the queries would stay the same but it could be changed to a distinct query.

With a little tweaking this boolean Flag could be provided via `Criteria` class, so it could be queried from the API.