### PR TITLE
Migrate to cucumber junit 5

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -616,14 +616,14 @@
                 <artifactId>spring-boot-starter-web-services</artifactId>
                 <version>${spring-boot.version}</version>
             </dependency>
-            <!-- Spring Cloud Netflix dependencies are no longer managed by Spring Cloud's BOM -->
-            <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2020.0-Release-Notes#breaking-changes -->
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
                 <scope>test</scope>
             </dependency>
+            <!-- Spring Cloud Netflix dependencies are no longer managed by Spring Cloud's BOM -->
+            <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2020.0-Release-Notes#breaking-changes -->
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -77,6 +77,8 @@
         <testcontainers.version>1.16.2</testcontainers.version>
         <xmemcached.version>2.4.7</xmemcached.version>
         <xmemcached-provider.version>4.1.3</xmemcached-provider.version>
+        <junit-platform>1.8.2</junit-platform>
+        <testng.version>7.4.0</testng.version>
     </properties>
 
     <dependencyManagement>
@@ -119,7 +121,7 @@
             </dependency>
             <dependency>
                 <groupId>io.cucumber</groupId>
-                <artifactId>cucumber-junit</artifactId>
+                <artifactId>cucumber-junit-platform-engine</artifactId>
                 <version>${cucumber-jvm.version}</version>
             </dependency>
             <dependency>
@@ -133,6 +135,7 @@
                 <artifactId>cucumber-spring</artifactId>
                 <version>${cucumber-jvm.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>com.google.code.simple-spring-memcached</groupId>
                 <artifactId>spring-cache</artifactId>
@@ -254,6 +257,12 @@
                 <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-jpamodelgen</artifactId>
                 <version>${hibernate.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-console</artifactId>
+                <version>${junit-platform}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.mapstruct</groupId>
@@ -610,6 +619,12 @@
             <!-- Spring Cloud Netflix dependencies are no longer managed by Spring Cloud's BOM -->
             <!-- https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2020.0-Release-Notes#breaking-changes -->
             <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
                 <version>${spring-cloud-netflix.version}</version>
@@ -720,7 +735,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            
+
             <dependency>
                 <groupId>com.playtika.reactivefeign</groupId>
                 <artifactId>feign-reactor-bom</artifactId>


### PR DESCRIPTION
Hi,

Really sorry @pascalgrimaud , I tried something: you know, I have my phases, and I'm currently in the 'traceability, unicity of the information' one (sometimes at the extreme).

This one is regarding a cucumber update to switch to a [junit 5-compatible version](https://github.com/jhipster/generator-jhipster/issues/17187), so it looks like the failed tests are expected.
I don't know how it works when I have to update the bom and the code as well: do we have to merge this one to get the snapshot version to ensure that the [cucumber templates](https://github.com/jhipster/generator-jhipster/pull/17188) works?

Maybe we could publish PR Bom's snapshots artifacts by default with a  qualifier (e.g. the PR number) in order to test it without merging in the main branch?