### PR TITLE
Change the calculation of max for service metrics

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/config/metric/JHipsterMetricsEndpoint.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/metric/JHipsterMetricsEndpoint.java
@@ -162,7 +162,7 @@ public class JHipsterMetricsEndpoint {
                 long count = httpTimersStream.stream().map(Timer::count).reduce((x, y) -> x + y).orElse(0L);
 
                 if (count != 0) {
-                    double max = httpTimersStream.stream().map(x -> x.max(TimeUnit.MILLISECONDS)).reduce((x, y) -> x > y ? x : y).orElse((double) 0);
+                    double max = httpTimersStream.stream().map(x -> x.totalTime(TimeUnit.MILLISECONDS)).reduce((x, y) -> x > y ? x : y).orElse((double) 0);
                     double totalTime = httpTimersStream.stream().map(x -> x.totalTime(TimeUnit.MILLISECONDS)).reduce((x, y) -> (x + y)).orElse((double) 0);
 
                     resultsPerUriPerCrudOperation.put("count", count);


### PR DESCRIPTION
The current calculation does not work and always returns 0. As the mean works correctly, I assume the max function on Timer does not return a useful value. As the code iterates through all requests anyway, it can also use the total time of one request and then take the largest value.