### PR TITLE
Migrate from Zalando to Spring Framework 6 problem support implementation #19991

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/web/rest/errors/ExceptionTranslation.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/web/rest/errors/ExceptionTranslation.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2022 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.jhipster.web.rest.errors;
+
+import org.springframework.web.server.ServerWebExchange;
+
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import reactor.core.publisher.Mono;
+
+/**
+ * The implementation of this interface is generally used to handle exceptions
+ * occuring prior to the ExceptionHandler selection in spring-web lifecycle.
+ * see https://github.com/spring-projects/spring-framework/issues/22991
+ */
+public interface ExceptionTranslation {
+    
+    /**
+     * Method to translate an Exception to ProblemDetail.
+     * @param ex The exception that needs to be handled
+     * @param request The request that is being served
+     * @return Returns the Responseentity containing the ProblemDetail
+     */
+    public Mono<ResponseEntity<ProblemDetail>> handleAnyException(Throwable ex, ServerWebExchange request);
+}

--- a/jhipster-framework/src/main/java/tech/jhipster/web/rest/errors/ReactiveWebExceptionHandler.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/web/rest/errors/ReactiveWebExceptionHandler.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-2022 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.jhipster.web.rest.errors;
+
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * ResponseStatusException handler for springwebflux(reactive) application
+ * that will facilitate the translation to ProblemDetail
+ */
+public class ReactiveWebExceptionHandler implements org.springframework.web.server.WebExceptionHandler {
+    
+    private final ExceptionTranslation translator;
+    private final ObjectMapper mapper;
+    
+    public ReactiveWebExceptionHandler(ExceptionTranslation translator, ObjectMapper mapper) {
+        this.translator = translator;
+        this.mapper = mapper;
+    }
+    
+    /**
+	 * Handle the given exception. A completion signal through the return value
+	 * indicates error handling is complete while an error signal indicates the
+	 * exception is still not handled.
+	 * @param exchange the current exchange
+	 * @param throwable the exception to handle
+	 * @return {@code Mono<Void>} to indicate when exception handling is complete
+	 */
+    @Override
+    public Mono<Void> handle(final ServerWebExchange exchange, final Throwable throwable) {
+        if (throwable instanceof ResponseStatusException) {
+            final Mono<ResponseEntity<ProblemDetail>> entityMono = translator.handleAnyException(throwable, exchange);
+            return entityMono.flatMap(entity -> this.setHttpResponse(entity, exchange, mapper));
+        }
+        return Mono.error(throwable);
+    }
+
+    private Mono<Void> setHttpResponse(final ResponseEntity<ProblemDetail> entity, final ServerWebExchange exchange,
+            final ObjectMapper mapper) {
+        final ServerHttpResponse response = exchange.getResponse();
+        response.setStatusCode(entity.getStatusCode());
+        response.getHeaders().addAll(entity.getHeaders());
+        try {
+            final DataBuffer buffer = response.bufferFactory()
+                    .wrap(mapper.writeValueAsBytes(entity.getBody()));
+            return response.writeWith(Mono.just(buffer))
+                    .doOnError(error -> DataBufferUtils.release(buffer));
+        } catch (final JsonProcessingException ex) {
+            return Mono.error(ex);
+        }
+    }
+}

--- a/jhipster-framework/src/test/java/tech/jhipster/web/rest/errors/ReactiveWebExceptionHandlerTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/web/rest/errors/ReactiveWebExceptionHandlerTest.java
@@ -1,0 +1,104 @@
+package tech.jhipster.web.rest.errors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebHandler;
+import org.springframework.web.server.adapter.WebHttpHandlerBuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import reactor.core.publisher.Mono;
+
+public class ReactiveWebExceptionHandlerTest {
+    
+    // Constants
+    private static final MediaType RESPONSE_TYPE = MediaType.APPLICATION_PROBLEM_JSON;
+    private static Log logger = LogFactory.getLog(ReactiveWebExceptionHandlerTest.class);
+    private static final String TITLE_REASON = "Test Reason";
+    private static final HttpStatus HANDLED_RESPONSE_STATUS = HttpStatus.METHOD_NOT_ALLOWED;
+    private static final HttpStatus NOT_HANDLED_RESPONSE_STATUS = HttpStatus.INTERNAL_SERVER_ERROR;
+    private static final ResponseStatusException EXCEPTION_TO_HANDLE = new ResponseStatusException(HANDLED_RESPONSE_STATUS, TITLE_REASON);
+    private static final IllegalStateException EXCEPTION_NOT_TO_HANDLE = new IllegalStateException("Test Exception");
+    private static final String PROBLEM_TYPE = "http://test.com/testExceptionTranslation";
+    private static final String expectedResponse = "{\"type\":\"http://test.com/testExceptionTranslation\",\"title\":\"Test Reason\",\"status\":405,\"detail\":null,\"instance\":null,\"properties\":null}";
+
+    @Test
+    void throwResponseStatusException() throws JsonMappingException, JsonProcessingException {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/").build();
+		MockServerHttpResponse response = new MockServerHttpResponse();
+
+		ReactiveWebExceptionHandler exceptionHandler = new ReactiveWebExceptionHandler(new TestExceptionTranslation(), new ObjectMapper());
+
+		WebHttpHandlerBuilder.webHandler(new TestWebHandler(EXCEPTION_TO_HANDLE))
+				.exceptionHandler(exceptionHandler).build()
+				.handle(request, response)
+				.block();
+		
+		assertEquals(HANDLED_RESPONSE_STATUS, response.getStatusCode());
+        assertEquals(RESPONSE_TYPE, response.getHeaders().getContentType());
+        assertEquals(expectedResponse, response.getBodyAsString().block());
+    }
+    
+    @Test
+    void throwOtherException() throws JsonMappingException, JsonProcessingException {
+        MockServerHttpRequest request = MockServerHttpRequest.get("/").build();
+        MockServerHttpResponse response = new MockServerHttpResponse();
+
+        ReactiveWebExceptionHandler exceptionHandler = new ReactiveWebExceptionHandler(new TestExceptionTranslation(), new ObjectMapper());
+
+        WebHttpHandlerBuilder.webHandler(new TestWebHandler(EXCEPTION_NOT_TO_HANDLE))
+                .exceptionHandler(exceptionHandler).build()
+                .handle(request, response)
+                .block();
+        
+        assertEquals(NOT_HANDLED_RESPONSE_STATUS, response.getStatusCode());
+    }
+    
+    private static ProblemDetail getProblemDetail() {
+        ProblemDetail problem = ProblemDetail.forStatus(EXCEPTION_TO_HANDLE.getStatusCode());
+        problem.setType(URI.create(PROBLEM_TYPE));
+        problem.setTitle(EXCEPTION_TO_HANDLE.getReason());
+        return problem;
+    } 
+
+    private static class TestExceptionTranslation implements ExceptionTranslation {
+
+        @Override
+        public Mono<ResponseEntity<ProblemDetail>> handleAnyException(Throwable ex, ServerWebExchange request) {
+            logger.trace("Stub ExceptionTranslation handleAnyException invoked");
+            ProblemDetail problem = getProblemDetail();
+            HttpHeaders header = new HttpHeaders();
+            header.setContentType(RESPONSE_TYPE);
+            return Mono.just(new ResponseEntity<>(problem, header, ((ResponseStatusException) ex).getStatusCode()));
+        }
+    }
+
+    private static class TestWebHandler implements WebHandler {  
+        private Throwable exception;
+        TestWebHandler(Throwable exception) {
+            this.exception = exception;
+        }
+
+        @Override
+        public Mono<Void> handle(org.springframework.web.server.ServerWebExchange exchange) {
+            logger.trace("StubHandler invoked.");
+			return Mono.error(this.exception);
+        }
+	}
+}


### PR DESCRIPTION
Class to handle ResponseStatusException and its derivatives as a framework class for webflux application.

related to jhipster/generator-jhipster#19991