### PR TITLE
drop infinispan managed dependency.

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -53,7 +53,6 @@
         <guava.version>31.1-jre</guava.version>
         <hazelcast.version>5.1.5</hazelcast.version>
         <hazelcast-hibernate5.version>2.2.1</hazelcast-hibernate5.version>
-        <infinispan.version>14.0.4.Final</infinispan.version>
         <!-- To pull in a newer version than Spring Boot with Nonnull -->
         <jakarta-annotation.version>2.1.1</jakarta-annotation.version>
         <jjwt.version>0.11.5</jjwt.version>
@@ -155,11 +154,6 @@
                 <groupId>org.redisson</groupId>
                 <artifactId>redisson</artifactId>
                 <version>${redisson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-spring-boot-starter-embedded</artifactId>
-                <version>${infinispan.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.jsonwebtoken</groupId>
@@ -687,14 +681,6 @@
                 <groupId>io.mongock</groupId>
                 <artifactId>mongock-bom</artifactId>
                 <version>${mongock.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.infinispan</groupId>
-                <artifactId>infinispan-bom</artifactId>
-                <version>${infinispan.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
infinispan dependency is managed by spring-boot.
It's customized. Adding the infinispan bom, I think we are overriding the customization.

See https://github.com/spring-projects/spring-boot/blob/bf1c18537779c44174725f79209f7bf6135f9c7d/spring-boot-project/spring-boot-autoconfigure/build.gradle#L114-L124