### PR TITLE
Sonar: Remove this use of 'setCookieName'; it is deprecated

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/config/locale/AngularCookieLocaleResolver.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/locale/AngularCookieLocaleResolver.java
@@ -48,6 +48,14 @@ public class AngularCookieLocaleResolver extends CookieLocaleResolver {
      */
     public static final String QUOTE = "%22";
 
+    public AngularCookieLocaleResolver() {
+        super();
+    }
+
+    public AngularCookieLocaleResolver(String cookieName) {
+        super(cookieName);
+    }
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/23141

Fix https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster-sample-application&open=AYT5NKCfoub84d7atcQh