### PR TITLE
Import spring-boot-starter-parent BOM

### DIFF
--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -65,6 +65,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- BOM import first so we (could) selectively override dependencies above -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>tech.jhipster</groupId>
                 <artifactId>jhipster-framework</artifactId>

--- a/jhipster-dependencies/pom.xml
+++ b/jhipster-dependencies/pom.xml
@@ -65,7 +65,7 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- BOM import first so we (could) selectively override dependencies above -->
+            <!-- BOM import first so it's possible to selectively override dependencies above -->
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-parent</artifactId>

--- a/jhipster-framework/pom.xml
+++ b/jhipster-framework/pom.xml
@@ -205,6 +205,18 @@
         </dependency>
     </dependencies>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <build>
         <plugins>
             <plugin>

--- a/jhipster-framework/pom.xml
+++ b/jhipster-framework/pom.xml
@@ -205,18 +205,6 @@
         </dependency>
     </dependencies>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-parent</artifactId>
-                <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
Fixes https://github.com/jhipster/generator-jhipster/issues/23883. 

Before this change, running the following in `jhipster-framework` pulls in Spring Framework 6.0.11:

```
$ mvn dependency:tree | grep org.springframework:
[INFO] |  \- org.springframework:spring-webmvc:jar:6.0.11:compile
[INFO] |     \- org.springframework:spring-expression:jar:6.0.11:compile
[INFO] |  \- org.springframework:spring-webflux:jar:6.0.11:compile
[INFO] |  +- org.springframework:spring-core:jar:6.0.11:compile
[INFO] |  |  \- org.springframework:spring-jcl:jar:6.0.11:compile
[INFO] |  +- org.springframework:spring-beans:jar:6.0.11:compile
[INFO] +- org.springframework:spring-context-support:jar:6.0.11:compile
[INFO] |  \- org.springframework:spring-context:jar:6.0.11:compile
[INFO] |  +- org.springframework:spring-aop:jar:6.0.11:compile
[INFO] |  |  \- org.springframework:spring-jdbc:jar:6.0.11:compile
[INFO] |  |  \- org.springframework:spring-orm:jar:6.0.11:compile
[INFO] |  \- org.springframework:spring-aspects:jar:6.0.11:compile
[INFO] |  +- org.springframework:spring-test:jar:6.0.11:test
```

After this change, it pulls in the correct version:

```
$ mvn dependency:tree | grep org.springframework:
[INFO] |  \- org.springframework:spring-webmvc:jar:6.0.13:compile
[INFO] |     \- org.springframework:spring-expression:jar:6.0.13:compile
[INFO] |  \- org.springframework:spring-webflux:jar:6.0.13:compile
[INFO] |  +- org.springframework:spring-core:jar:6.0.13:compile
[INFO] |  |  \- org.springframework:spring-jcl:jar:6.0.13:compile
[INFO] |  +- org.springframework:spring-beans:jar:6.0.13:compile
[INFO] +- org.springframework:spring-context-support:jar:6.0.13:compile
[INFO] |  \- org.springframework:spring-context:jar:6.0.13:compile
[INFO] |  +- org.springframework:spring-aop:jar:6.0.13:compile
[INFO] |  |  \- org.springframework:spring-jdbc:jar:6.0.13:compile
[INFO] |  |  \- org.springframework:spring-orm:jar:6.0.13:compile
[INFO] |  \- org.springframework:spring-aspects:jar:6.0.13:compile
[INFO] |  +- org.springframework:spring-test:jar:6.0.13:test
[INFO] |  \- org.springframework:spring-web:jar:6.0.13:compile
[INFO] |  \- org.springframework:spring-tx:jar:6.0.13:compile
```