### PR TITLE
use gradle develocity for build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Test with Maven
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-        run: ./mvnw test --batch-mode
+        run: ./mvnw clean test --batch-mode
       - name: Run Sonar analysis
         if: github.repository == 'jhipster/jhipster-bom' && github.event_name == 'push'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
           java-version: 17
           cache: 'maven'
       - name: Test with Maven
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: ./mvnw test --batch-mode
       - name: Run Sonar analysis
         if: github.repository == 'jhipster/jhipster-bom' && github.event_name == 'push'

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ Desktop.ini
 node_modules
 package-lock.json
 
+#.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+

--- a/.gitignore
+++ b/.gitignore
@@ -126,5 +126,5 @@ Desktop.ini
 node_modules
 package-lock.json
 
-#.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
 

--- a/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+++ b/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
@@ -1,0 +1,1 @@
+fwqyqstozvesdoqt67hizw534e

--- a/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+++ b/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
@@ -1,1 +1,0 @@
-fwqyqstozvesdoqt67hizw534e

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.20</version>
+    <version>1.20.1</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,12 @@
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>gradle-enterprise-maven-extension</artifactId>
+    <version>1.20</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>1.12.5</version>
+  </extension>
+</extensions>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,25 @@
+<gradleEnterprise>
+  <server>
+    <url>https://ge.jhipster.tech</url>
+  </server>
+  <buildScan>
+    <capture>                                         
+      <goalInputFiles>true</goalInputFiles>
+    </capture>
+    <publish>ALWAYS</publish>
+    <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
+    <publishIfAuthenticated>true</publishIfAuthenticated>
+    <obfuscation>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
+  </buildScan>
+    <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</gradleEnterprise>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -15,7 +15,7 @@
   </buildScan>
     <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
       <enabled>true</enabled>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -15,7 +15,7 @@
   </buildScan>
     <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
       <enabled>false</enabled>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -15,10 +15,10 @@
   </buildScan>
     <buildCache>
     <local>
-      <enabled>true</enabled>
+      <enabled>false</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## JHipster BOM and server-side library
 
-[![Angular Build Status][github-actions-angular-image]][github-actions-url] [![React Build Status][github-actions-react-image]][github-actions-url] [![Vue Build Status][github-actions-vue-image]][github-actions-url] [![Maven Central][maven-image]][maven-url]
+[![Angular Build Status][github-actions-angular-image]][github-actions-url] [![React Build Status][github-actions-react-image]][github-actions-url] [![Vue Build Status][github-actions-vue-image]][github-actions-url] [![Maven Central][maven-image]][maven-url] [![Revved up by Develocity][develocity-badge]][develocity-url]
 
 Full documentation and information is available on our website at [https://www.jhipster.tech/][jhipster-url]
 
@@ -31,3 +31,6 @@ If the current version is SNAPSHOT then to use this SNAPSHOT version:
 [sonar-coverage]: https://sonarcloud.io/api/project_badges/measure?project=jhipster-framework&metric=coverage
 [sonar-bugs]: https://sonarcloud.io/api/project_badges/measure?project=jhipster-framework&metric=bugs
 [sonar-vulnerabilities]: https://sonarcloud.io/api/project_badges/measure?project=jhipster-framework&metric=vulnerabilities
+
+[develocity-badge]: https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A
+[develocity-url]: https://ge.jhipster.tech/scans

--- a/jhipster-framework/pom.xml
+++ b/jhipster-framework/pom.xml
@@ -204,7 +204,6 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -429,7 +429,27 @@
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${versions-maven-plugin.version}</version>
                 </plugin>
-            </plugins>
+              <plugin>
+                    <groupId>com.gradle</groupId>
+                    <artifactId>gradle-enterprise-maven-extension</artifactId>
+                    <configuration>
+                        <gradleEnterprise>
+                        <normalization>
+                            <runtimeClassPath>
+                            <propertiesNormalizations>
+                                <propertiesNormalization>
+                                <path>**/git.properties</path>
+                                <ignoredProperties>
+                                    <ignore>jhipster-lib.git.build.time</ignore>
+                                </ignoredProperties>
+                                </propertiesNormalization>
+                            </propertiesNormalizations>
+                            </runtimeClassPath>
+                        </normalization>
+                        </gradleEnterprise>
+                    </configuration>
+                    </plugin>
+        </plugins>
         </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -446,51 +446,28 @@
                                 </propertiesNormalizations>
                                 </runtimeClassPath>
                             </normalization>
-                        </gradleEnterprise>
-                        <plugins>
+                            <plugins>
                             <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>
                                 <artifactId>maven-enforcer-plugin</artifactId>
                                 <executions>
                                     <execution>
                                         <id>enforce-versions</id>
+                                        <outputs>
+                                            <cacheableBecause>version check should be cached</cacheableBecause>
+                                        </outputs>
                                     </execution>
                                     <execution>
                                         <id>enforce-dependencyConvergence</id>
-                                        <inputs>
-                                            <properties>
-                                            <property>
-                                                <name>fail</name>
-                                            </property>
-                                            <property>
-                                                <name>failFast</name>
-                                            </property>
-                                            <property>
-                                                <name>failIfNoRules</name>
-                                            </property>
-                                            <property>
-                                                <name>rulesToSkip</name>
-                                            </property>
-                                            <property>
-                                                <name>rulesToExecute</name>
-                                            </property>
-                                            <property>
-                                                <name>rules</name>
-                                            </property>
-                                            <property>
-                                                <name>skip</name>
-                                            </property>
-                                            </properties>
-                                            <ignoredProperties>
-                                            <ignore>ignoreCache</ignore>
-                                            <ignore>mojoExecution</ignore>
-                                            <ignore>session</ignore>
-                                            </ignoredProperties>
-                                        </inputs>
+                                         <outputs>
+                                            <cacheableBecause>depencency convergenve should be cached</cacheableBecause>
+                                        </outputs>
                                     </execution>
                                 </executions>
                             </plugin>
                         </plugins>
+                        </gradleEnterprise>
+
                     </configuration>
                 </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -456,12 +456,130 @@
                                         <outputs>
                                             <cacheableBecause>version check should be cached</cacheableBecause>
                                         </outputs>
+                                        <inputs>
+                                            <properties>
+                                                <property>
+                                                    <name>fail</name>
+                                                </property>
+                                                <property>
+                                                    <name>failFast</name>
+                                                </property>
+                                                <property>
+                                                    <name>failIfNoRules</name>
+                                                </property>
+                                                <property>
+                                                    <name>rulesToSkip</name>
+                                                </property>
+                                                <property>
+                                                    <name>rulesToExecute</name>
+                                                </property>
+                                                <property>
+                                                    <name>rules</name>
+                                                </property>
+                                                <property>
+                                                    <name>skip</name>
+                                                </property>
+                                            </properties>
+                                                <ignoredProperties>
+                                                <ignore>ignoreCache</ignore>
+                                                <ignore>mojoExecution</ignore>
+                                                <ignore>session</ignore>
+                                            </ignoredProperties>
+                                        </inputs>
+                                         <nestedProperties>
+                                            <property>
+                                            <name>project</name>
+                                            <iteratedProperties>
+                                                <property>
+                                                <name>dependencies</name>
+                                                <inputs>
+                                                    <properties>
+                                                    <property>
+                                                        <name>groupId</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>artifactId</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>version</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>type</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>scope</name>
+                                                    </property>
+                                                    </properties>
+                                                </inputs>
+                                                </property>
+                                            </iteratedProperties>
+                                            </property>
+                                        </nestedProperties>
                                     </execution>
                                     <execution>
                                         <id>enforce-dependencyConvergence</id>
                                          <outputs>
                                             <cacheableBecause>depencency convergenve should be cached</cacheableBecause>
                                         </outputs>
+                                         <inputs>
+                                            <properties>
+                                                <property>
+                                                    <name>fail</name>
+                                                </property>
+                                                <property>
+                                                    <name>failFast</name>
+                                                </property>
+                                                <property>
+                                                    <name>failIfNoRules</name>
+                                                </property>
+                                                <property>
+                                                    <name>rulesToSkip</name>
+                                                </property>
+                                                <property>
+                                                    <name>rulesToExecute</name>
+                                                </property>
+                                                <property>
+                                                    <name>rules</name>
+                                                </property>
+                                                <property>
+                                                    <name>skip</name>
+                                                </property>
+                                            </properties>
+                                                <ignoredProperties>
+                                                <ignore>ignoreCache</ignore>
+                                                <ignore>mojoExecution</ignore>
+                                                <ignore>session</ignore>
+                                            </ignoredProperties>
+                                        </inputs>
+                                         <nestedProperties>
+                                            <property>
+                                            <name>project</name>
+                                            <iteratedProperties>
+                                                <property>
+                                                <name>dependencies</name>
+                                                <inputs>
+                                                    <properties>
+                                                    <property>
+                                                        <name>groupId</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>artifactId</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>version</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>type</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>scope</name>
+                                                    </property>
+                                                    </properties>
+                                                </inputs>
+                                                </property>
+                                            </iteratedProperties>
+                                            </property>
+                                        </nestedProperties>
                                     </execution>
                                 </executions>
                             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -429,26 +429,70 @@
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>${versions-maven-plugin.version}</version>
                 </plugin>
-              <plugin>
+                <plugin>
                     <groupId>com.gradle</groupId>
                     <artifactId>gradle-enterprise-maven-extension</artifactId>
                     <configuration>
                         <gradleEnterprise>
-                        <normalization>
-                            <runtimeClassPath>
-                            <propertiesNormalizations>
-                                <propertiesNormalization>
-                                <path>**/git.properties</path>
-                                <ignoredProperties>
-                                    <ignore>jhipster-lib.git.build.time</ignore>
-                                </ignoredProperties>
-                                </propertiesNormalization>
-                            </propertiesNormalizations>
-                            </runtimeClassPath>
-                        </normalization>
+                            <normalization>
+                                <runtimeClassPath>
+                                <propertiesNormalizations>
+                                    <propertiesNormalization>
+                                    <path>**/git.properties</path>
+                                    <ignoredProperties>
+                                        <ignore>jhipster-lib.git.build.time</ignore>
+                                    </ignoredProperties>
+                                    </propertiesNormalization>
+                                </propertiesNormalizations>
+                                </runtimeClassPath>
+                            </normalization>
                         </gradleEnterprise>
+                        <plugins>
+                            <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <executions>
+                                    <execution>
+                                        <id>enforce-versions</id>
+                                    </execution>
+                                    <execution>
+                                        <id>enforce-dependencyConvergence</id>
+                                        <inputs>
+                                            <properties>
+                                            <property>
+                                                <name>fail</name>
+                                            </property>
+                                            <property>
+                                                <name>failFast</name>
+                                            </property>
+                                            <property>
+                                                <name>failIfNoRules</name>
+                                            </property>
+                                            <property>
+                                                <name>rulesToSkip</name>
+                                            </property>
+                                            <property>
+                                                <name>rulesToExecute</name>
+                                            </property>
+                                            <property>
+                                                <name>rules</name>
+                                            </property>
+                                            <property>
+                                                <name>skip</name>
+                                            </property>
+                                            </properties>
+                                            <ignoredProperties>
+                                            <ignore>ignoreCache</ignore>
+                                            <ignore>mojoExecution</ignore>
+                                            <ignore>session</ignore>
+                                            </ignoredProperties>
+                                        </inputs>
+                                    </execution>
+                                </executions>
+                            </plugin>
+                        </plugins>
                     </configuration>
-                    </plugin>
+                </plugin>
         </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Thanks to Nelson and Gasper from the Gradle team we have now build scans and build cache for maven. This PR enables build scan and caching for the bom. When this is merged and everything works will I will create the PR for jh lite, which really speeds up the build. Maybe I need someone to add the secret for write access to our develocity instance.

EDIT: Please squash on merge