### PR TITLE
Update endpoint in JHipsterMetricsEndpoint comment

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/config/metric/JHipsterMetricsEndpoint.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/config/metric/JHipsterMetricsEndpoint.java
@@ -36,7 +36,7 @@ public class JHipsterMetricsEndpoint {
     }
 
     /**
-     * GET /management/jhi-metrics
+     * GET /management/jhimetrics
      * <p>
      * Give metrics displayed on Metrics page
      *


### PR DESCRIPTION
## Description

This pull request updates the endpoint reference in the comment of the `JHipsterMetricsEndpoint` class from `/management/jhi-metrics` to `/management/jhimetrics` to match the recent change in the `@WebEndpoint(id = "jhimetrics")`.