### PR TITLE
feat: add CriteriaBuilder for Spring Data R2DBC queries

### DIFF
--- a/jhipster-framework/src/main/java/tech/jhipster/service/CriteriaBuilder.java
+++ b/jhipster-framework/src/main/java/tech/jhipster/service/CriteriaBuilder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2016-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.jhipster.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.relational.core.query.Criteria;
+import tech.jhipster.service.filter.Filter;
+import tech.jhipster.service.filter.RangeFilter;
+import tech.jhipster.service.filter.StringFilter;
+
+/**
+ * Class for constructing {@link Criteria} from the entity criteria, i.e. {@link Filter},
+ * so they can be applied to Spring Data R2DBC queries.
+ */
+public class CriteriaBuilder {
+
+    private final List<Criteria> allCriteria = new ArrayList<>();
+
+    /**
+     * Method that takes in a filter field and an entity property to construct a compounded {@link Criteria}.
+     * The built criteria can be retrieved using the buildCriteria function.
+     * @param <X> 		field type
+     * @param field 	the actual filter field
+     * @param property 	the entity property for which the criteria is constructed
+     */
+    public <X> void buildFilterCriteriaForField(Filter<X> field, String property) {
+        if (field instanceof StringFilter stringFilter) {
+            buildStringCriteria(stringFilter, property);
+        } else if (field instanceof RangeFilter<?> rangeFilter) {
+            buildRangeCriteria(rangeFilter, property);
+        }
+        buildGeneralCriteria(field, property);
+    }
+
+    /**
+     * Method that builds and returns the compounded {@link Criteria} object. This method can be called
+     * multiple times as the criteria are being built.
+     * @return returns the compounded criteria object
+     */
+    public Criteria buildCriteria() {
+        return Criteria.from(allCriteria);
+    }
+
+    private void buildRangeCriteria(RangeFilter<?> rangeData, String property) {
+        if (rangeData.getGreaterThan() != null) {
+            allCriteria.add(Criteria.where(property).greaterThan(rangeData.getGreaterThan()));
+        }
+        if (rangeData.getLessThan() != null) {
+            allCriteria.add(Criteria.where(property).lessThan(rangeData.getLessThan()));
+        }
+        if (rangeData.getGreaterThanOrEqual() != null) {
+            allCriteria.add(Criteria.where(property).greaterThanOrEquals(rangeData.getGreaterThanOrEqual()));
+        }
+        if (rangeData.getLessThanOrEqual() != null) {
+            allCriteria.add(Criteria.where(property).lessThanOrEquals(rangeData.getLessThanOrEqual()));
+        }
+    }
+
+    private void buildStringCriteria(StringFilter stringData, String property) {
+        if (stringData.getContains() != null) {
+            allCriteria.add(Criteria.where(property).like("%" + stringData.getContains() + "%"));
+        }
+        if (stringData.getDoesNotContain() != null) {
+            allCriteria.add(Criteria.where(property).notLike("%" + stringData.getDoesNotContain() + "%"));
+        }
+    }
+
+    private <X> void buildGeneralCriteria(Filter<X> generalData, String property) {
+        if (generalData.getEquals() != null) {
+            allCriteria.add(Criteria.where(property).is(generalData.getEquals()));
+        }
+        if (generalData.getNotEquals() != null) {
+            allCriteria.add(Criteria.where(property).not(generalData.getNotEquals()));
+        }
+        if (generalData.getIn() != null && !generalData.getIn().isEmpty()) {
+            allCriteria.add(Criteria.where(property).in(generalData.getIn()));
+        }
+        if (generalData.getNotIn() != null && !generalData.getNotIn().isEmpty()) {
+            allCriteria.add(Criteria.where(property).notIn(generalData.getNotIn()));
+        }
+        if (generalData.getSpecified() != null) {
+            allCriteria.add(
+                Boolean.TRUE.equals(generalData.getSpecified()) ? Criteria.where(property).isNotNull() : Criteria.where(property).isNull()
+            );
+        }
+    }
+}

--- a/jhipster-framework/src/test/java/tech/jhipster/service/CriteriaBuilderTest.java
+++ b/jhipster-framework/src/test/java/tech/jhipster/service/CriteriaBuilderTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2016-2026 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tech.jhipster.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.CriteriaDefinition.Comparator;
+import tech.jhipster.service.filter.BooleanFilter;
+import tech.jhipster.service.filter.LongFilter;
+import tech.jhipster.service.filter.StringFilter;
+
+class CriteriaBuilderTest {
+
+    private CriteriaBuilder builder;
+
+    @BeforeEach
+    void setup() {
+        builder = new CriteriaBuilder();
+    }
+
+    @Test
+    void shouldBuildEmptyCriteriaWhenNoFilterIsSet() {
+        builder.buildFilterCriteriaForField(new StringFilter(), "name");
+        builder.buildFilterCriteriaForField(new LongFilter(), "id");
+
+        assertThat(builder.buildCriteria().isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldBuildEqualsCriteria() {
+        StringFilter filter = new StringFilter();
+        filter.setEquals("jhipster");
+
+        builder.buildFilterCriteriaForField(filter, "name");
+
+        Criteria criteria = builder.buildCriteria();
+        assertThat(criteria.getColumn()).hasToString("name");
+        assertThat(criteria.getComparator()).isEqualTo(Comparator.EQ);
+        assertThat(criteria.getValue()).isEqualTo("jhipster");
+    }
+
+    @Test
+    void shouldBuildGeneralCriteria() {
+        BooleanFilter filter = new BooleanFilter();
+        filter.setNotEquals(true);
+        filter.setIn(List.of(true, false));
+        filter.setNotIn(List.of(false));
+        filter.setSpecified(true);
+
+        builder.buildFilterCriteriaForField(filter, "active");
+
+        assertThat(builder.buildCriteria()).hasToString(
+            "(active != 'true' AND active IN ('true', 'false') AND active NOT IN ('false') AND active IS NOT NULL)"
+        );
+    }
+
+    @Test
+    void shouldBuildNotSpecifiedCriteria() {
+        LongFilter filter = new LongFilter();
+        filter.setSpecified(false);
+
+        builder.buildFilterCriteriaForField(filter, "id");
+
+        assertThat(builder.buildCriteria()).hasToString("id IS NULL");
+    }
+
+    @Test
+    void shouldIgnoreEmptyInAndNotIn() {
+        LongFilter filter = new LongFilter();
+        filter.setIn(List.of());
+        filter.setNotIn(List.of());
+
+        builder.buildFilterCriteriaForField(filter, "id");
+
+        assertThat(builder.buildCriteria().isEmpty()).isTrue();
+    }
+
+    @Test
+    void shouldBuildStringCriteria() {
+        StringFilter filter = new StringFilter();
+        filter.setContains("jhip");
+        filter.setDoesNotContain("spring");
+
+        builder.buildFilterCriteriaForField(filter, "name");
+
+        assertThat(builder.buildCriteria()).hasToString("(name LIKE '%jhip%' AND name NOT LIKE '%spring%')");
+    }
+
+    @Test
+    void shouldBuildRangeCriteria() {
+        LongFilter filter = new LongFilter();
+        filter.setGreaterThan(1L);
+        filter.setLessThan(10L);
+        filter.setGreaterThanOrEqual(2L);
+        filter.setLessThanOrEqual(9L);
+
+        builder.buildFilterCriteriaForField(filter, "id");
+
+        assertThat(builder.buildCriteria()).hasToString("(id > 1 AND id < 10 AND id >= 2 AND id <= 9)");
+    }
+
+    @Test
+    void shouldCombineCriteriaFromMultipleFields() {
+        StringFilter nameFilter = new StringFilter();
+        nameFilter.setEquals("jhipster");
+        LongFilter idFilter = new LongFilter();
+        idFilter.setGreaterThan(1L);
+
+        builder.buildFilterCriteriaForField(nameFilter, "name");
+        builder.buildFilterCriteriaForField(idFilter, "id");
+
+        assertThat(builder.buildCriteria()).hasToString("(name = 'jhipster' AND id > 1)");
+    }
+}


### PR DESCRIPTION
Moved from generator-jhipster, where it was generated into every reactive SQL application using entity filtering. It builds a Spring Data relational Criteria from the tech.jhipster.service.filter filters.